### PR TITLE
[FIX] 값이 2024-06-09보다 작아야한다는 오류 수정

### DIFF
--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -246,7 +246,6 @@ export default function Result() {
                   icon="calendar_month"
                   value={date()}
                   min="2015-02-26"
-                  max={new Date().toISOString().split("T")[0]}
                   aria-label="가입일"
                   onChange={e => {
                     setDate(e.currentTarget.value)


### PR DESCRIPTION
## 수정 사항
아래와 같은 기능이 수정/변경되었습니다.

* 값이 2024-06-09보다 작아야한다는 오류를 수정합니다.

## 비고
머지 시 바로 배포됩니다. (별도 설정 필요 X)
