### PR TITLE
[FIX] 일부 기기에서 스크린샷 다운로드 시 글꼴 깨짐 현상 수정

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -5,7 +5,8 @@ import { MetaProvider, Title, Link, Meta } from "@solidjs/meta"
 import { Router } from "@solidjs/router"
 import { FileRoutes } from "@solidjs/start/router"
 
-import { JSDELIVR_CDN, TOSSFACE_CDN, WANTED_SANS_CDN } from "./constants/styles"
+import { JSDELIVR_CDN, TOSSFACE_CDN, WANTED_SANS_CDN } from "~/constants/styles"
+import ToastMessage from "~/components/ToastMessage"
 
 import "./globals.css"
 
@@ -37,9 +38,12 @@ export default function App() {
         <MetaProvider>
           <Title>왁큘레이터 - 왁물원 등급 계산기</Title>
 
-          <Link rel="preconnect" href={JSDELIVR_CDN} crossorigin="anonymous" />
-          <Link rel="stylesheet" href={WANTED_SANS_CDN} />
-          <Link rel="stylesheet" href={TOSSFACE_CDN} />
+          <Link rel="preconnect" href={JSDELIVR_CDN} crossOrigin="anonymous" />
+          <Link rel="preload" href={WANTED_SANS_CDN} crossOrigin="anonymous" as="style" />
+          <Link rel="preload" href={TOSSFACE_CDN} crossOrigin="anonymous" as="style" />
+
+          <Link rel="stylesheet" href={WANTED_SANS_CDN} crossOrigin="anonymous" />
+          <Link rel="stylesheet" href={TOSSFACE_CDN} crossOrigin="anonymous" />
 
           <Link rel="canonical" href="https://www.wakulator.xyz/" />
 
@@ -64,6 +68,7 @@ export default function App() {
       )}
     >
       <FileRoutes />
+      <ToastMessage />
     </Router>
   )
 }

--- a/src/components/ToastMessage.tsx
+++ b/src/components/ToastMessage.tsx
@@ -1,0 +1,69 @@
+import { createEffect, createSignal } from "solid-js"
+import { Portal } from "solid-js/web"
+
+import { ToastMessageStyle } from "~/styles/components/toastMessage"
+import { toast, setToast } from "~/stores/toastMessage"
+
+export default function ToastMessage() {
+  const [fadeType, setFadeType] = createSignal<"fadeInUp" | "fadeOutDown">("fadeInUp") // fadeOut 애니메이션도 추가하기
+
+  let timer: NodeJS.Timeout | null = null // FadeOut Timer
+  let deleteTimer: NodeJS.Timeout | null = null // Element 삭제하는 Timer
+
+  createEffect(() => {
+    if (toast.message) {
+      // 이미 타이머가 동작 중이라면 초기화
+      if (deleteTimer) {
+        clearTimeout(deleteTimer)
+        deleteTimer = null
+      }
+      if (timer) {
+        clearTimeout(timer)
+        timer = null
+      }
+
+      setFadeType("fadeInUp")
+
+      // 3초 or duration 뒤 fadeOut 토글
+      // duration이 없으면 3초로 설정, null이면 무한대기
+
+      if (toast.duration === null) {
+        return () => {
+          setFadeType("fadeOutDown")
+
+          setTimeout(() => {
+            setToast({ message: null, duration: undefined }) // fadeOut 끝난 뒤 element 삭제
+            setFadeType("fadeInUp") // 나중에 다시 toggle될때 대비해서 초기화
+          }, 500)
+        }
+      }
+
+      timer = setTimeout(() => {
+        setFadeType("fadeOutDown")
+
+        deleteTimer = setTimeout(() => {
+          setToast({ message: null, duration: undefined }) // fadeOut 끝난 뒤 element 삭제
+          setFadeType("fadeInUp") // 나중에 다시 toggle될때 대비해서 초기화
+        }, 500)
+      }, toast.duration ?? 3000)
+
+      return () => {
+        clearTimeout(deleteTimer!)
+        deleteTimer = null
+
+        clearTimeout(timer!)
+        timer = null
+      }
+    }
+  }, [toast.message, setToast])
+
+  return (
+    toast && (
+      <Portal mount={document.getElementById("root") ?? undefined}>
+        <ToastMessageStyle isVisible={!!toast.message} fadeType={fadeType()}>
+          <ToastMessageStyle.Text>{toast.message}</ToastMessageStyle.Text>
+        </ToastMessageStyle>
+      </Portal>
+    )
+  )
+}

--- a/src/stores/toastMessage.ts
+++ b/src/stores/toastMessage.ts
@@ -1,0 +1,6 @@
+import { createStore } from "solid-js/store"
+
+export const [toast, setToast] = createStore<{
+  message: string | null
+  duration?: number | null
+}>({ message: null })

--- a/src/styles/components/toastMessage.tsx
+++ b/src/styles/components/toastMessage.tsx
@@ -1,0 +1,60 @@
+import { keyframes, styled } from "solid-styled-components"
+
+// 아래에서 위로 올라오는 FadeIn
+const _FadeInUpAnimation = keyframes`
+  0% {
+    opacity: 0;
+    transform: translate(-50%, 30px);
+  }
+  100% {
+    opacity: 1;
+    transform: translate(-50%, 0);
+  }
+`
+
+// 다시 아래로 내려가는 FadeOut
+const _FadeOutDownAnimation = keyframes`
+  0% {
+    opacity: 1;
+    transform: translate(-50%, 0);
+  }
+  100% {
+    opacity: 0;
+    transform: translate(-50%, 30px);
+  }
+`
+
+const _Container = styled("div")<{ fadeType: "fadeInUp" | "fadeOutDown"; isVisible: boolean }>(
+  props => `
+    background-color: #666666;
+    padding: 24px 38px;
+    border-radius: 10px;
+
+    width: max-content;
+    height: fit-content;
+
+    position: fixed;
+    display: ${props.isVisible ? "flex" : "none"};
+
+    z-index: 99;
+    left: 50%;
+    bottom: 5%;
+
+    opacity: 0;
+    transform: translate(-50%, 30px);
+    animation: ${props.fadeType === "fadeInUp" ? _FadeInUpAnimation : _FadeOutDownAnimation} 0.5s forwards;
+  `,
+)
+
+const _Text = styled("p")`
+  color: white;
+  font-size: 18px;
+  font-style: normal;
+  font-weight: 600;
+  margin: 0px;
+  letter-spacing: -0.18px;
+`
+
+export const ToastMessageStyle = Object.assign(_Container, {
+  Text: _Text,
+})

--- a/src/utils/calcLevel.ts
+++ b/src/utils/calcLevel.ts
@@ -1,4 +1,5 @@
 import { levelInfo } from "~/data/wakzoo_levels"
+import { setToast } from "~/stores/toastMessage"
 
 export const validateInput = (articleCount?: number, commentCount?: number, visitCount?: number, date?: string) => {
   // Validation
@@ -21,7 +22,7 @@ export const validateInput = (articleCount?: number, commentCount?: number, visi
     new Date(date!) < new Date("2015-02-25T18:28:00.000Z") ||
     new Date(date!) > new Date()
   ) {
-    alert("입력하신 값을 다시 확인해주세요.")
+    setToast({ message: "입력하신 값을 다시 확인해주세요." })
     return
   }
 }


### PR DESCRIPTION
## 수정 사항
아래와 같은 기능이 수정/변경되었습니다.

* 일부 기기에서 스크린샷 다운로드 시, 글꼴이 깨져서 저장되는 현상을 수정합니다.
* 스크린샷 다운로드를 위해 폰트 파일을 불러오는 시간 동안, Toast message를 출력합니다.

## 비고
머지 시 바로 배포됩니다. (별도 설정 필요 X)
