### PR TITLE
[FIX] duration값 누락으로 인한 디바이스 별 toast message 노출 차이 문제 수정

### DIFF
--- a/src/components/ResultTable.tsx
+++ b/src/components/ResultTable.tsx
@@ -72,7 +72,7 @@ export default function ResultTable(props: { data: typeof inputData; isPrintMode
     if (window.matchMedia("(max-width: 767px)").matches) {
       setToast({ message: "이미지를 만들고 있어요.", duration: null })
     } else {
-      setToast({ message: "이미지를 만들고 있어요. 잠시만 기다려 주세요." })
+      setToast({ message: "이미지를 만들고 있어요. 잠시만 기다려 주세요.", duration: null })
     }
 
     domToPng(domToPngContext()!).then((dataUrl: string) => {


### PR DESCRIPTION
## 수정 사항
아래와 같은 기능이 수정/변경되었습니다.

* duration값 누락으로 인해, 786px 이상인 디바이스에서 toast message 노출이 제대로 이루어 지지 않는 문제를 수정합니다.

## 비고
머지 시 바로 배포됩니다. (별도 설정 필요 X)
