### PR TITLE
[FIX] 스크린샷 다운로드 시 푸터 예상등업일 레이아웃 깨짐 수정

### DIFF
--- a/src/components/ResultTable.tsx
+++ b/src/components/ResultTable.tsx
@@ -69,7 +69,7 @@ export default function ResultTable(props: { data: typeof inputData; isPrintMode
 
     setIsNowDownloading(true)
 
-    if (window.matchMedia("(max-width: 767px)").matches) {
+    if (window.matchMedia("(max-width: 768px)").matches) {
       setToast({ message: "이미지를 만들고 있어요.", duration: null })
     } else {
       setToast({ message: "이미지를 만들고 있어요. 잠시만 기다려 주세요.", duration: null })

--- a/src/components/ResultTable.tsx
+++ b/src/components/ResultTable.tsx
@@ -217,7 +217,7 @@ export default function ResultTable(props: { data: typeof inputData; isPrintMode
 
         {/* 결과창 예상 등급변경일 정보 & 다운로드 버튼 */}
         <ResultTableStyle.Footer>
-          <ul>
+          <ResultTableStyle.Footer.EstimatedDate>
             <Show when={result()!.index < 4}>
               <For each={[result()!.index + 1, result()!.index + 2]}>
                 {index => {
@@ -230,43 +230,47 @@ export default function ResultTable(props: { data: typeof inputData; isPrintMode
                   )
 
                   return (
-                    <ResultTableStyle.Footer.EstimatedDate>
+                    <ResultTableStyle.Footer.EstimatedDate.Text>
                       {nextLevelTime
                         ? `${levelInfo[index].name} : ${nextLevelTime}`
                         : index === 2
                           ? "침하! 왁물원 공지를 확인해 주세요!"
                           : ""}
-                    </ResultTableStyle.Footer.EstimatedDate>
+                    </ResultTableStyle.Footer.EstimatedDate.Text>
                   )
                 }}
               </For>
             </Show>
 
             <Show when={result()!.index == 4}>
-              <ResultTableStyle.Footer.EstimatedDate>
+              <ResultTableStyle.Footer.EstimatedDate.Text>
                 {levelInfo[5].name} :{" "}
                 {calcNextLevelTime(5, props.data.article, props.data.comment, props.data.visit, props.data.date)}
-              </ResultTableStyle.Footer.EstimatedDate>
+              </ResultTableStyle.Footer.EstimatedDate.Text>
 
-              <ResultTableStyle.Footer.EstimatedDate>
+              <ResultTableStyle.Footer.EstimatedDate.Text>
                 슬슬 냄시가 나기 시작하는군요.
-              </ResultTableStyle.Footer.EstimatedDate>
+              </ResultTableStyle.Footer.EstimatedDate.Text>
             </Show>
 
             <Show when={result()!.index == 6}>
-              <ResultTableStyle.Footer.EstimatedDate>뭔가 아담하시군요.</ResultTableStyle.Footer.EstimatedDate>
+              <ResultTableStyle.Footer.EstimatedDate.Text>
+                뭔가 아담하시군요.
+              </ResultTableStyle.Footer.EstimatedDate.Text>
             </Show>
 
             <Show when={result()!.index == 7}>
-              <ResultTableStyle.Footer.EstimatedDate>철컥 탕탕탕탕탕</ResultTableStyle.Footer.EstimatedDate>
+              <ResultTableStyle.Footer.EstimatedDate.Text>철컥 탕탕탕탕탕</ResultTableStyle.Footer.EstimatedDate.Text>
             </Show>
 
             <Show when={result()!.index == 8}>
-              <ResultTableStyle.Footer.EstimatedDate>좀 모시깽하군요</ResultTableStyle.Footer.EstimatedDate>
+              <ResultTableStyle.Footer.EstimatedDate.Text>좀 모시깽하군요</ResultTableStyle.Footer.EstimatedDate.Text>
             </Show>
 
             <Show when={result()!.index == 9}>
-              <ResultTableStyle.Footer.EstimatedDate>느그자의 부름에 응한다..!</ResultTableStyle.Footer.EstimatedDate>
+              <ResultTableStyle.Footer.EstimatedDate.Text>
+                느그자의 부름에 응한다..!
+              </ResultTableStyle.Footer.EstimatedDate.Text>
             </Show>
 
             <Show when={result()!.index == 5}>
@@ -274,24 +278,24 @@ export default function ResultTable(props: { data: typeof inputData; isPrintMode
                 when={Math.random() < 0.5}
                 fallback={
                   <>
-                    <ResultTableStyle.Footer.EstimatedDate>
+                    <ResultTableStyle.Footer.EstimatedDate.Text>
                       더 이상 달성할 등급이 없어요...
-                    </ResultTableStyle.Footer.EstimatedDate>
+                    </ResultTableStyle.Footer.EstimatedDate.Text>
                     <br />
 
-                    <ResultTableStyle.Footer.EstimatedDate>으 냄시....</ResultTableStyle.Footer.EstimatedDate>
+                    <ResultTableStyle.Footer.EstimatedDate.Text>으 냄시....</ResultTableStyle.Footer.EstimatedDate.Text>
                   </>
                 }
               >
-                <ResultTableStyle.Footer.EstimatedDate>
+                <ResultTableStyle.Footer.EstimatedDate.Text>
                   느그자 개체수가 너무 많아요...
-                </ResultTableStyle.Footer.EstimatedDate>
+                </ResultTableStyle.Footer.EstimatedDate.Text>
                 <br />
 
-                <ResultTableStyle.Footer.EstimatedDate>환생 ㄱ?</ResultTableStyle.Footer.EstimatedDate>
+                <ResultTableStyle.Footer.EstimatedDate.Text>환생 ㄱ?</ResultTableStyle.Footer.EstimatedDate.Text>
               </Show>
             </Show>
-          </ul>
+          </ResultTableStyle.Footer.EstimatedDate>
 
           <Show when={!props.isPrintMode}>
             <ResultTableStyle.Footer.DownloadBtn onClick={() => downloadImage()}>

--- a/src/styles/components/resultTable.tsx
+++ b/src/styles/components/resultTable.tsx
@@ -108,16 +108,19 @@ const _ResultFooterWrapper = styled("section")`
   justify-content: space-between;
 `
 
-const _ResultEstimatedDate = styled("li")`
+const _ResultEstimatedDate = styled("ul")`
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  width: 100%;
+`
+
+const _ResultEstimatedDateText = styled("li")`
   color: #666666;
   list-style: none;
 
   font-size: 12px;
   font-weight: 400;
-
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
 `
 
 const _ResultDownloadBtn = styled("button")`
@@ -146,7 +149,9 @@ export const ResultTableStyle = Object.assign(_Result, {
     Label: _ResultTextLabel,
   }),
   Footer: Object.assign(_ResultFooterWrapper, {
-    EstimatedDate: _ResultEstimatedDate,
+    EstimatedDate: Object.assign(_ResultEstimatedDate, {
+      Text: _ResultEstimatedDateText,
+    }),
     DownloadBtn: _ResultDownloadBtn,
   }),
 })

--- a/src/styles/components/toastMessage.tsx
+++ b/src/styles/components/toastMessage.tsx
@@ -27,7 +27,7 @@ const _FadeOutDownAnimation = keyframes`
 const _Container = styled("div")<{ fadeType: "fadeInUp" | "fadeOutDown"; isVisible: boolean }>(
   props => `
     background-color: #666666;
-    padding: 24px 38px;
+    padding: 20px 34px;
     border-radius: 10px;
 
     width: max-content;
@@ -43,16 +43,24 @@ const _Container = styled("div")<{ fadeType: "fadeInUp" | "fadeOutDown"; isVisib
     opacity: 0;
     transform: translate(-50%, 30px);
     animation: ${props.fadeType === "fadeInUp" ? _FadeInUpAnimation : _FadeOutDownAnimation} 0.5s forwards;
+
+    @media (max-width: 768px) {
+        padding: 18px 32px;
+    }
   `,
 )
 
 const _Text = styled("p")`
   color: white;
-  font-size: 18px;
+  font-size: 16px;
   font-style: normal;
   font-weight: 600;
   margin: 0px;
   letter-spacing: -0.18px;
+
+  @media (max-width: 768px) {
+    font-size: 14px;
+  }
 `
 
 export const ToastMessageStyle = Object.assign(_Container, {


### PR DESCRIPTION
## 수정 사항
아래와 같은 기능이 수정/변경되었습니다.

* 스크린샷 다운로드 시 푸터 예상등업일 레이아웃 깨짐 문제를 수정합니다.
* 토스트메시지의 글자크기를 조금 작게 조정합니다.

## 비고
머지 시 바로 배포됩니다. (별도 설정 필요 X)
