### PR TITLE
[FIX] 이스터에그 등업예정일 푸터 레이아웃 깨짐 수정

### DIFF
--- a/src/components/ResultTable.tsx
+++ b/src/components/ResultTable.tsx
@@ -280,7 +280,6 @@ export default function ResultTable(props: { data: typeof inputData; isPrintMode
                     <ResultTableStyle.Footer.EstimatedDate.Text>
                       더 이상 달성할 등급이 없어요...
                     </ResultTableStyle.Footer.EstimatedDate.Text>
-                    <br />
 
                     <ResultTableStyle.Footer.EstimatedDate.Text>으 냄시....</ResultTableStyle.Footer.EstimatedDate.Text>
                   </>
@@ -289,7 +288,6 @@ export default function ResultTable(props: { data: typeof inputData; isPrintMode
                 <ResultTableStyle.Footer.EstimatedDate.Text>
                   느그자 개체수가 너무 많아요...
                 </ResultTableStyle.Footer.EstimatedDate.Text>
-                <br />
 
                 <ResultTableStyle.Footer.EstimatedDate.Text>환생 ㄱ?</ResultTableStyle.Footer.EstimatedDate.Text>
               </Show>


### PR DESCRIPTION
## 수정 사항
아래와 같은 기능이 수정/변경되었습니다.

* 느그자 등 이스터에그 등업예정일이 나오는 푸터 레이아웃이 깨지는 문제를 수정합니다.

## 비고
머지 시 바로 배포됩니다. (별도 설정 필요 X)
